### PR TITLE
Update Pydantic version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==3.7.3
-pydantic==2.4.0
+pydantic>=2.6
 fastapi==0.109.1 
 uvicorn==0.23.2    
 streamlit==1.37.0     


### PR DESCRIPTION
## Summary
- update `pydantic` requirement so Streamlit Cloud can use newer wheels

## Testing
- `python -m compileall -q .`
- `streamlit run app/Home.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e8dc0fa883208b5f31e2462298b0