### PR TITLE
Improve memory estimation for modern LLMs

### DIFF
--- a/app/backend/data_model.py
+++ b/app/backend/data_model.py
@@ -12,3 +12,4 @@ class Memory(BaseModel):
     tensor_parallelism: int = None
     optimizer: str = None
     percent_trainable_parameters: int = None
+    gradient_checkpointing: bool = True

--- a/app/backend/serve.py
+++ b/app/backend/serve.py
@@ -5,6 +5,7 @@ import requests
 
 app = FastAPI()
 
+
 @app.get("/ping")
 async def ping():
     """Ping server to determine status
@@ -16,13 +17,14 @@ async def ping():
     """
     return {"message": "Server is Running"}
 
+
 @app.post("/calculate_memory")
 async def calculate_memory(payload: Memory):
     # Example memory calculation logic
-    precision_dict = {"FP32":4, "FP16": 2, "8BIT": 1, "4BIT": 0.5}
-    optimizer_dict = {"AdamW":12, "Adam": 8, "bitsandbytes_8bit": 6, "SGD-like": 8}
+    precision_dict = {"FP32": 4, "FP16": 2, "8BIT": 1, "4BIT": 0.5}
+    optimizer_dict = {"AdamW": 12, "Adam": 8, "bitsandbytes_8bit": 6, "SGD-like": 8}
     parameters_billions = payload.parameters * 1000000000
-    bytes_to_gb_factor = 1024**3 # factor to convert Bytes to GBs for Human Readability
+    bytes_to_gb_factor = 1024**3  # factor to convert Bytes to GBs for Human Readability
 
     # parsing inputs
     batch_size = payload.batch_size
@@ -35,27 +37,64 @@ async def calculate_memory(payload: Memory):
     tensor_parallelism = payload.tensor_parallelism
     optimizer = payload.optimizer
     percent_trainable_parameters = payload.percent_trainable_parameters
+    gradient_checkpointing = payload.gradient_checkpointing
 
-    model_weights_memory = (parameters_billions * precision_dict[precision]) / bytes_to_gb_factor
-    kv_cache_memory = (2 * batch_size * sequence_length * layer_count * hidden_size * precision_dict[precision]) / bytes_to_gb_factor
-    activations_memory = (batch_size * sequence_length * hidden_size * (34 + (5 * sequence_length * attention_heads) / hidden_size) * precision_dict[precision]) / bytes_to_gb_factor
+    model_weights_memory = (
+        parameters_billions * precision_dict[precision]
+    ) / bytes_to_gb_factor
+    kv_cache_memory = (
+        2
+        * batch_size
+        * sequence_length
+        * layer_count
+        * hidden_size
+        * precision_dict[precision]
+    ) / bytes_to_gb_factor
+    if gradient_checkpointing:
+        activations_memory = (
+            batch_size * sequence_length * hidden_size * 24 * precision_dict[precision]
+        ) / bytes_to_gb_factor
+    else:
+        activations_memory = (
+            batch_size
+            * sequence_length
+            * hidden_size
+            * (34 + (5 * sequence_length * attention_heads) / hidden_size)
+            * precision_dict[precision]
+            * layer_count
+        ) / bytes_to_gb_factor
     # activations_memory = (batch_size * sequence_length * hidden_size * layer_count * (
     #     10 + (24 / tensor_parallelism) + (5 * ((attention_heads * sequence_length) / (hidden_size * tensor_parallelism)))
     # )) / bytes_to_gb_factor
-    optimizer_memory = (optimizer_dict[optimizer] * parameters_billions) / bytes_to_gb_factor
-    gradient_memory = (parameters_billions * precision_dict["FP32"]) / bytes_to_gb_factor
+    optimizer_memory = (
+        optimizer_dict[optimizer] * parameters_billions
+    ) / bytes_to_gb_factor
+    gradient_memory = (
+        parameters_billions * precision_dict["FP32"]
+    ) / bytes_to_gb_factor
 
     standard_training_total_memory_gb = (
-        model_weights_memory + kv_cache_memory + activations_memory + ((optimizer_memory + gradient_memory) * (percent_trainable_parameters / 100))
-    )*1.05
-    standard_inference_total_memory_gb = (model_weights_memory + kv_cache_memory + activations_memory)*1.05
+        model_weights_memory
+        + kv_cache_memory
+        + activations_memory
+        + ((optimizer_memory + gradient_memory) * (percent_trainable_parameters / 100))
+    ) * 1.05
+    standard_inference_total_memory_gb = (
+        model_weights_memory + kv_cache_memory + activations_memory
+    ) * 1.05
 
-
-    RESULTS = {'model_weights_memory':model_weights_memory, 'kv_cache_memory':kv_cache_memory, 'activations_memory':activations_memory,
-    'optimizer_memory':optimizer_memory, 'gradient_memory':gradient_memory, 'standard_inference_total_memory_gb':standard_inference_total_memory_gb,
-    'standard_training_total_memory_gb':standard_training_total_memory_gb}
+    RESULTS = {
+        "model_weights_memory": model_weights_memory,
+        "kv_cache_memory": kv_cache_memory,
+        "activations_memory": activations_memory,
+        "optimizer_memory": optimizer_memory,
+        "gradient_memory": gradient_memory,
+        "standard_inference_total_memory_gb": standard_inference_total_memory_gb,
+        "standard_training_total_memory_gb": standard_training_total_memory_gb,
+    }
 
     return {"msg": "Memory Calculation Complete", "Calculation": RESULTS}
+
 
 if __name__ == "__main__":
     uvicorn.run("serve:app", host="0.0.0.0", port=8000, log_level="info")

--- a/app/pages/memory_calculator.py
+++ b/app/pages/memory_calculator.py
@@ -3,20 +3,45 @@ import requests
 from PIL import Image
 from utils.memory_utils import llm_memory_GPU_distribution, calculate_memory
 
-#Flag if using endpoint config
-backend_endpoint = False 
+# Flag if using endpoint config
+backend_endpoint = False
 
 # Load Logos
-amd_logo = Image.open('./app/digital_assets/amd.png')
-nvidia_logo = Image.open('./app/digital_assets/nvidia.png')
+amd_logo = Image.open("./app/digital_assets/amd.png")
+nvidia_logo = Image.open("./app/digital_assets/nvidia.png")
 
 # Model Data Dictionary
 model_dictionaries = {
-    "Llama 3 70B Instruct": {"parameters": 70, "hidden_size": 8192, "layer_count": 80, "attention_heads": 64},
-    "Llama 3 8B Instruct": {"parameters": 8, "hidden_size": 4096, "layer_count": 32, "attention_heads": 32},
-    "Qwen 72B Instruct": {"parameters": 72, "hidden_size": 8192, "layer_count": 80, "attention_heads": 64},
-    "DeepSeek-R1": {"parameters": 671, "hidden_size": 7168, "layer_count": 61, "attention_heads": 128},
-    "Llama 3.1 405B": {"parameters": 405, "hidden_size": 16384, "layer_count": 126, "attention_heads": 128},
+    "Llama 3 70B Instruct": {
+        "parameters": 70,
+        "hidden_size": 8192,
+        "layer_count": 80,
+        "attention_heads": 64,
+    },
+    "Llama 3 8B Instruct": {
+        "parameters": 8,
+        "hidden_size": 4096,
+        "layer_count": 32,
+        "attention_heads": 32,
+    },
+    "Qwen 72B Instruct": {
+        "parameters": 72,
+        "hidden_size": 8192,
+        "layer_count": 80,
+        "attention_heads": 64,
+    },
+    "DeepSeek-R1": {
+        "parameters": 671,
+        "hidden_size": 7168,
+        "layer_count": 61,
+        "attention_heads": 128,
+    },
+    "Llama 3.1 405B": {
+        "parameters": 405,
+        "hidden_size": 16384,
+        "layer_count": 126,
+        "attention_heads": 128,
+    },
 }
 
 
@@ -24,31 +49,61 @@ Models = list(model_dictionaries.keys()) + ["Custom"]
 
 st.set_page_config(page_title="LLM Memory Calculator", layout="wide")
 st.title("📊 LLM Memory Requirement Calculator")
-st.write("All total memory requirements include and additional 5% memory buffer to account for minor calculation errors and to reserve compute for background tasks")
+st.write(
+    "All total memory requirements include and additional 5% memory buffer to account for minor calculation errors and to reserve compute for background tasks"
+)
 
 with st.sidebar:
     st.header("⚙️ Model Configuration")
     prefill_model = st.selectbox("Prefill Model Selection", options=Models)
-    
+
     # Dynamically set default values
     defaults = model_dictionaries.get(prefill_model, {})
-    
-    parameters = st.number_input("Parameters (B)", min_value=1, value=defaults.get("parameters", 1))
+
+    parameters = st.number_input(
+        "Parameters (B)", min_value=1, value=defaults.get("parameters", 1)
+    )
     batch_size = st.number_input("Batch Size", min_value=1, value=1)
     precision = st.selectbox("Precision", ["FP16", "8BIT", "4BIT", "FP32"])
-    sequence_length = st.number_input("Sequence Length", min_value=1, value=2048, help="Considerations must be made for the context length support intended for training and inference. 2048 is just a placeholder based on Llama 3 limits.")
-    hidden_size = st.number_input("Hidden Size", min_value=1, value=defaults.get("hidden_size", 1))
-    layer_count = st.number_input("Layer Count", min_value=1, value=defaults.get("layer_count", 1))
-    attention_heads = st.number_input("Attention Heads", min_value=1, value=defaults.get("attention_heads", 1))
+    sequence_length = st.number_input(
+        "Sequence Length",
+        min_value=1,
+        value=2048,
+        help="Considerations must be made for the context length support intended for training and inference. 2048 is just a placeholder based on Llama 3 limits.",
+    )
+    hidden_size = st.number_input(
+        "Hidden Size", min_value=1, value=defaults.get("hidden_size", 1)
+    )
+    layer_count = st.number_input(
+        "Layer Count", min_value=1, value=defaults.get("layer_count", 1)
+    )
+    attention_heads = st.number_input(
+        "Attention Heads", min_value=1, value=defaults.get("attention_heads", 1)
+    )
     tensor_parallelism = st.number_input("Tensor Parallelism", min_value=1, value=1)
-    optimizer = st.selectbox("Optimizer", ["AdamW", "Adam", "bitsandbytes_8bit", "SGD-like"])
-    percent_trainable_parameters = st.slider("% Trainable Parameters", min_value=1, max_value=100, value=100)
-    
+    optimizer = st.selectbox(
+        "Optimizer", ["AdamW", "Adam", "bitsandbytes_8bit", "SGD-like"]
+    )
+    percent_trainable_parameters = st.slider(
+        "% Trainable Parameters", min_value=1, max_value=100, value=100
+    )
+    gradient_checkpointing = st.checkbox("Enable Gradient Checkpointing", value=True)
 
     if st.button("🔍 Calculate Memory Usage"):
         try:
-            st.session_state["response"] = calculate_memory(parameters, batch_size, precision, sequence_length, hidden_size, layer_count, attention_heads,
-            tensor_parallelism, optimizer, percent_trainable_parameters)
+            st.session_state["response"] = calculate_memory(
+                parameters,
+                batch_size,
+                precision,
+                sequence_length,
+                hidden_size,
+                layer_count,
+                attention_heads,
+                tensor_parallelism,
+                optimizer,
+                percent_trainable_parameters,
+                gradient_checkpointing,
+            )
             st.success("✅ Calculation Complete!")
         except:
             st.warning("Calculation Failed!")
@@ -60,23 +115,33 @@ if "response" in st.session_state:
         response_data = st.session_state["response"]["Calculation"]
     except:
         response_data = st.session_state["response"]
-    
+
     inference_tab, training_tab = st.tabs(["🚀 Inference", "🎯 Training"])
-    
+
     with inference_tab:
-        st.metric(label="**Total Inference Memory (GB)**", value=f"{response_data['standard_inference_total_memory_gb']:.2f}")
+        st.metric(
+            label="**Total Inference Memory (GB)**",
+            value=f"{response_data['standard_inference_total_memory_gb']:.2f}",
+        )
         st.write(f"- **Model Weights**: {response_data['model_weights_memory']:.2f} GB")
         st.write(f"- **KV Cache**: {response_data['kv_cache_memory']:.2f} GB")
-        st.write(f"- **Activation Memory**: {response_data['activations_memory']:.2f} GB")
-    
+        st.write(
+            f"- **Activation Memory**: {response_data['activations_memory']:.2f} GB"
+        )
+
     with training_tab:
-        st.metric(label="**Total Training Memory (GB)**", value=f"{response_data['standard_training_total_memory_gb']:.2f}")
+        st.metric(
+            label="**Total Training Memory (GB)**",
+            value=f"{response_data['standard_training_total_memory_gb']:.2f}",
+        )
         st.write(f"- **Model Weights**: {response_data['model_weights_memory']:.2f} GB")
         st.write(f"- **KV Cache**: {response_data['kv_cache_memory']:.2f} GB")
-        st.write(f"- **Activation Memory**: {response_data['activations_memory']:.2f} GB")
+        st.write(
+            f"- **Activation Memory**: {response_data['activations_memory']:.2f} GB"
+        )
         st.write(f"- **Optimizer Memory**: {response_data['optimizer_memory']:.2f} GB")
         st.write(f"- **Gradient Memory**: {response_data['gradient_memory']:.2f} GB")
-    
+
     st.subheader("🖥️ GPU Requirements")
     col1, col2, col3, col4, col5, col6 = st.columns(6)
 
@@ -86,38 +151,58 @@ if "response" in st.session_state:
         ("MI325X (256GB)", amd_logo, 256),
         ("H200 (141GB)", nvidia_logo, 141),
         ("MI355X (288GB)", amd_logo, 288),
-        ("B200 (192GB)", nvidia_logo, 192)
+        ("B200 (192GB)", nvidia_logo, 192),
     ]
 
-    for col, (gpu_name, logo, memory) in zip([col1, col2, col3, col4, col5, col6], gpu_configs):
+    for col, (gpu_name, logo, memory) in zip(
+        [col1, col2, col3, col4, col5, col6], gpu_configs
+    ):
         with col:
             st.image(logo, width=80)
             st.subheader(gpu_name)
-    
+
             # Get inference/training memory distributions
-            inference_gpu = llm_memory_GPU_distribution(response_data['standard_inference_total_memory_gb'], memory, 8, attention_heads, tensor_parallelism)
-            training_gpu = llm_memory_GPU_distribution(response_data['standard_training_total_memory_gb'], memory, 8, attention_heads, tensor_parallelism)
-    
+            inference_gpu = llm_memory_GPU_distribution(
+                response_data["standard_inference_total_memory_gb"],
+                memory,
+                8,
+                attention_heads,
+                tensor_parallelism,
+            )
+            training_gpu = llm_memory_GPU_distribution(
+                response_data["standard_training_total_memory_gb"],
+                memory,
+                8,
+                attention_heads,
+                tensor_parallelism,
+            )
+
             # Debugging: Ensure the function returns expected data
             st.write("Debug - Inference GPU:", inference_gpu)
             st.write("Debug - Training GPU:", training_gpu)
-    
+
             # Inference Check
             if inference_gpu.get("attention_heads_divisible", False):
                 if inference_gpu.get("fits_on_one_gpu", False):
                     st.success("✅ Fits on Single GPU for Inference")
                 else:
-                    st.warning(f"⚠️ Requires {inference_gpu.get('num_gpus_needed', '?')} GPUs for Inference")
+                    st.warning(
+                        f"⚠️ Requires {inference_gpu.get('num_gpus_needed', '?')} GPUs for Inference"
+                    )
             else:
-                st.error("❌ Attention Heads Not Evenly Divisible - Check Tensor Parallelism")
-    
+                st.error(
+                    "❌ Attention Heads Not Evenly Divisible - Check Tensor Parallelism"
+                )
+
             # Training Check
             if training_gpu.get("attention_heads_divisible", False):
                 if training_gpu.get("fits_on_one_gpu", False):
                     st.success("✅ Fits on Single GPU for Training")
                 else:
-                    st.warning(f"⚠️ Requires {training_gpu.get('num_gpus_needed', '?')} GPUs for Training")
+                    st.warning(
+                        f"⚠️ Requires {training_gpu.get('num_gpus_needed', '?')} GPUs for Training"
+                    )
             else:
-                st.error("❌ Attention Heads Not Evenly Divisible - Check Tensor Parallelism")
-    
-    
+                st.error(
+                    "❌ Attention Heads Not Evenly Divisible - Check Tensor Parallelism"
+                )


### PR DESCRIPTION
## Summary
- support gradient checkpointing by default in memory calculation
- add toggle for gradient checkpointing in UI
- include gradient checkpointing in FastAPI backend
- update model data schema and memory formulas

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847c591213c8320a2becb329adc36d7