### PR TITLE
Add tests for memory utilities

### DIFF
--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -1,0 +1,50 @@
+import sys
+sys.path.append('app')
+import pytest
+
+from utils import memory_utils as mu
+
+
+def test_llm_memory_gpu_distribution_fits():
+    res = mu.llm_memory_GPU_distribution(10, 20, 8, 8, 4)
+    assert res == {
+        "fits_on_one_gpu": True,
+        "num_gpus_needed": 1,
+        "num_nodes_needed": 1,
+        "attention_heads_divisible": True,
+    }
+
+
+def test_llm_memory_gpu_distribution_not_divisible():
+    res = mu.llm_memory_GPU_distribution(10, 5, 8, 8, 3)
+    assert res == {
+        "error": "Attention heads must be evenly divisible by the tensor parallelism value."
+    }
+
+
+def test_calculate_memory_training_values():
+    res = mu.calculate_memory(
+        parameters=1,
+        batch_size=1,
+        precision="FP16",
+        sequence_length=1,
+        hidden_size=1,
+        layer_count=1,
+        attention_heads=1,
+        tensor_parallelism=1,
+        optimizer="AdamW",
+        percent_trainable_parameters=100,
+        mode="training",
+        gradient_checkpointing=True,
+    )
+    assert pytest.approx(res["model_weights_memory"], rel=1e-6) == 1.862645149230957
+    assert pytest.approx(res["kv_cache_memory"], rel=1e-6) == 3.725290298461914e-09
+    assert pytest.approx(res["standard_training_total_memory_gb"], rel=1e-6) == 17.60199671108276
+
+
+def test_recommend_parallelism_strategy_paths():
+    assert mu.recommend_parallelism_strategy(10, 1, 10, 10, 20)["strategy"] == "Data Parallelism"
+    assert mu.recommend_parallelism_strategy(200, 50, 100, 120, 80)["strategy"] == "Hybrid Parallelism (TP+PP)"
+    assert mu.recommend_parallelism_strategy(200, 100, 50, 50, 80)["strategy"] == "Tensor Parallelism"
+    assert mu.recommend_parallelism_strategy(200, 50, 70, 50, 80)["strategy"] == "Pipeline Parallelism"
+    assert mu.recommend_parallelism_strategy(200, 50, 50, 50, 80)["strategy"] == "Tensor Parallelism"

--- a/tests/test_show_strategy.py
+++ b/tests/test_show_strategy.py
@@ -1,0 +1,58 @@
+import sys
+import ast
+sys.path.append('app')
+from utils import memory_utils
+
+source = open('app/pages/memory_calculator.py').read()
+module = ast.parse(source)
+func_src = None
+for node in module.body:
+    if isinstance(node, ast.FunctionDef) and node.name == 'show_strategy_if_instinct':
+        func_src = ast.get_source_segment(source, node)
+        break
+
+globals_dict = {
+    'recommend_parallelism_strategy': memory_utils.recommend_parallelism_strategy,
+    'st': None,
+}
+exec(func_src, globals_dict)
+show_strategy_if_instinct = globals_dict['show_strategy_if_instinct']
+
+class DummySt:
+    def __init__(self):
+        self.called = False
+        self.last = None
+    def markdown(self, text, unsafe_allow_html=False):
+        self.called = True
+        self.last = text
+
+
+def test_show_strategy_runs_on_instinct(monkeypatch):
+    st = DummySt()
+    monkeypatch.setitem(globals_dict, 'st', st)
+    monkeypatch.setitem(globals_dict, 'recommend_parallelism_strategy', lambda *a, **k: {'strategy': 'Test', 'icon': 'I', 'reason': 'R'})
+    show_strategy_if_instinct(
+        'MI300X',
+        100,
+        {'standard_inference_total_memory_gb': 1, 'model_weights_memory': 1},
+        {'standard_training_total_memory_gb': 1, 'model_weights_memory': 1},
+        1,
+        1,
+    )
+    assert st.called
+    assert 'Inference: Test' in st.last and 'Training: Test' in st.last
+
+
+def test_show_strategy_skips_non_instinct(monkeypatch):
+    st = DummySt()
+    monkeypatch.setitem(globals_dict, 'st', st)
+    monkeypatch.setitem(globals_dict, 'recommend_parallelism_strategy', lambda *a, **k: {'strategy': 'Test', 'icon': 'I', 'reason': 'R'})
+    show_strategy_if_instinct(
+        'H100',
+        100,
+        {'standard_inference_total_memory_gb': 1, 'model_weights_memory': 1},
+        {'standard_training_total_memory_gb': 1, 'model_weights_memory': 1},
+        1,
+        1,
+    )
+    assert not st.called


### PR DESCRIPTION
## Summary
- add pytest unit tests for memory utility functions
- add unit tests for `show_strategy_if_instinct`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a36aa79108320948f09f6a6080b75