### PR TITLE
Fix missing strategy variables in memory calculator

### DIFF
--- a/app/pages/memory_calculator.py
+++ b/app/pages/memory_calculator.py
@@ -22,6 +22,20 @@ def show_strategy_if_instinct(
     if not gpu_name.startswith("MI"):
         return
 
+    inference_strategy = recommend_parallelism_strategy(
+        inference_data["standard_inference_total_memory_gb"],
+        inference_data["model_weights_memory"],
+        layer_count,
+        parameters,
+        memory,
+    )
+    training_strategy = recommend_parallelism_strategy(
+        training_data["standard_training_total_memory_gb"],
+        training_data["model_weights_memory"],
+        layer_count,
+        parameters,
+        memory,
+    )
 
     st.markdown(
         f"""


### PR DESCRIPTION
## Summary
- fix `show_strategy_if_instinct` to compute inference and training strategies before rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a527b29a8832087c3d4406873bd4c